### PR TITLE
ヘッダ画像レスポンシブ対応

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -562,7 +562,7 @@ section h2 span {
 	#mainImg img{
 		display:block;
 		margin: 0 auto;
-		padding-top: 70px;
+		padding-top: 40px;
 	}
 	.col3 li{
 		margin: 50px auto 0 auto;


### PR DESCRIPTION
ヘッダ画像、サイズ小さくした際に見切れていたのを対応
<img width="459" alt="スクリーンショット 2021-08-01 11 45 03" src="https://user-images.githubusercontent.com/41239012/127757443-f77b2163-97ed-4677-9239-b1da2348e254.png">

